### PR TITLE
Fix onlineframe slider scrollframe nil value

### DIFF
--- a/UnBot/OnlineFrame.xml
+++ b/UnBot/OnlineFrame.xml
@@ -246,7 +246,9 @@
 					OnlineFrame.slider = self;
 				</OnLoad>
 				<OnValueChanged>
-					OnlineFrame.scrollFrame:SetVerticalScroll(self:GetValue());
+					if (OnlineFrame.scrollFrame ~= nil) then
+						OnlineFrame.scrollFrame:SetVerticalScroll(self:GetValue());
+					end
 				</OnValueChanged>
 			</Scripts>
           </Slider>


### PR DESCRIPTION
Add a nil check to `OnlineFrameSlider:OnValueChanged` to prevent a Lua error when `OnlineFrame.scrollFrame` is uninitialized.

---

[Open in Web](https://cursor.com/agents?id=bc-810f1c7f-e56e-437a-bfef-f365a09e0537) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-810f1c7f-e56e-437a-bfef-f365a09e0537) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)