### PR TITLE
Fix wow addon class filter error

### DIFF
--- a/YssBossLoot/Core.lua
+++ b/YssBossLoot/Core.lua
@@ -21,8 +21,6 @@ local sin = math.sin
 local cos = math.cos
 local pi = math.pi
 
-YssBossLoot.filters = {}
-
 local enableLootTooltip
 local dropdowntype = nil --'type', 'zone', 'level'
 local lootParent

--- a/YssBossLoot/g.lua
+++ b/YssBossLoot/g.lua
@@ -1,1 +1,3 @@
-YssBossLoot = {}; 
+YssBossLoot = {};
+YssBossLoot.filters = {};
+YssBossLoot.filterOptions = {}; 


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Initialize `YssBossLoot.filters` and `YssBossLoot.filterOptions` earlier to resolve 'attempt to index field 'filters' (a nil value)' Lua error.

---

[Open in Web](https://cursor.com/agents?id=bc-b813dcd0-7ca3-4989-afc5-19fad92292ef) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-b813dcd0-7ca3-4989-afc5-19fad92292ef) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)