### PR TITLE
Fix wow addon world map nil value

### DIFF
--- a/YssBossLoot/WorldMapSupport.lua
+++ b/YssBossLoot/WorldMapSupport.lua
@@ -5,8 +5,10 @@ local ORANGE_FONT_COLOR_CODE = "|cffff7f3f";
 local YBL_WMS = {}
 
 local L = LibStub("AceLocale-3.0"):GetLocale("YssBossLoot", true)
-local BZ = LibStub("LibBabble-Zone-3.0", true):GetUnstrictLookupTable()
-local BB = LibStub("LibBabble-Boss-3.0", true):GetUnstrictLookupTable()
+local BZ_lib = LibStub("LibBabble-Zone-3.0", true)
+local BZ = BZ_lib and BZ_lib:GetUnstrictLookupTable() or {}
+local BB_lib = LibStub("LibBabble-Boss-3.0", true)
+local BB = BB_lib and BB_lib:GetUnstrictLookupTable() or {}
 
 local function GetMapType()
 	local id = GetCurrentMapAreaID() - 1

--- a/YssBossLoot/YssBossLoot.toc
+++ b/YssBossLoot/YssBossLoot.toc
@@ -12,6 +12,7 @@
 ## Author: Yssaril
 ## Version: v1.0.3
 ## LoadOnDemand: 1
+## OptionalDeps: LibBabble-Zone-3.0, LibBabble-Boss-3.0
 ## SavedVariables: YssBossLootDB, YssBossLootMissingTranslations
 
 g.lua


### PR DESCRIPTION
Safely initialize LibBabble variables to prevent "attempt to index a nil value" errors when libraries are missing.

The error occurred because `LibStub("LibBabble-Boss-3.0", true)` could return `nil` if the library was not available, leading to an attempt to call `:GetUnstrictLookupTable()` on a nil value. This fix introduces a check for the library's existence before calling methods and provides an empty table as a fallback, ensuring the addon functions correctly even without the optional localization libraries.

---

[Open in Web](https://cursor.com/agents?id=bc-294fb653-a51d-43a8-9701-56d350513a33) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-294fb653-a51d-43a8-9701-56d350513a33) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)